### PR TITLE
Support get layout by context & noTestWrapConfig prop

### DIFF
--- a/getLayout.js
+++ b/getLayout.js
@@ -1,0 +1,40 @@
+import { Component, PropTypes, createElement } from 'react';
+
+import hoistStatics from 'hoist-non-react-statics';
+
+const defaultMapLayoutToProps = layout => layout;
+const mergeProps = (contextProps, props) => ({
+    ...contextProps,
+    ...props
+});
+
+const getDisplayName = WrappedComponent =>
+    WrappedComponent.displayName || WrappedComponent.name || 'Component';
+
+export default function getLayout(mapLayoutToProps = defaultMapLayoutToProps, options = {}) {
+    return WrappedComponent => {
+
+        class GetLayout extends Component {
+            static displayName = `GetLayout(${getDisplayName(WrappedComponent)})`;
+
+            static contextTypes = {
+                layoutTesterState: PropTypes.object.isRequired
+            };
+
+            mergedProps = mergeProps(mapLayoutToProps(this.context.layoutTesterState), this.props);
+
+            componentWillReceiveProps(nextProps, nextContext) {
+                this.mergedProps = mergeProps(mapLayoutToProps(nextContext.layoutTesterState), nextProps);
+            }
+
+            render() {
+                const renderProps = options.withRef ?
+                    { ...this.mergedProps, ref: 'wrapInstance' } :
+                    this.mergedProps;
+                return createElement(WrappedComponent, renderProps);
+            }
+        }
+
+        return hoistStatics(GetLayout, WrappedComponent)
+    };
+};

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ import {
     TouchableOpacity,
     View
 } from "react-native";
+import shallowEqual from 'shallowequal';
 
 import styles from "./styles";
 import getLayout from './getLayout';
@@ -17,6 +18,12 @@ export default class LayoutTester extends Component {
     static propTypes = {
         children: PropTypes.node,
         config: PropTypes.object,
+        noTestWrapConfig: PropTypes.shape({
+            mode: PropTypes.string.isRequired,
+            width: PropTypes.number.isRequired,
+            height: PropTypes.number.isRequired,
+            portrait: PropTypes.bool,
+        }),
         viewportChanged: PropTypes.func
     };
 
@@ -40,13 +47,23 @@ export default class LayoutTester extends Component {
         }
     };
 
-    state = {
-        portrait: true
-    };
-
     static childContextTypes = {
       layoutTesterState: PropTypes.object
     };
+
+    constructor(props) {
+        super(props);
+        if (props.noTestWrapConfig) {
+            let { mode, width, height, portrait } = props.noTestWrapConfig;
+            this.state = {
+                mode,
+                viewport: { width, height },
+                portrait: !!portrait
+            };
+        } else {
+            this.state = { portrait: true };
+        }
+    }
 
     getChildContext() {
         return {
@@ -54,15 +71,40 @@ export default class LayoutTester extends Component {
         };
     }
 
+    componentWillReceiveProps(nextProps) {
+        if (shallowEqual(this.props.noTestWrapConfig, nextProps.noTestWrapConfig)) return;
+
+        if (!nextProps.noTestWrapConfig) {
+            let config = this.props.config;
+            let mode = Object.keys(config)[0];
+            this.setDefaultConfig(mode, config[mode]);
+            return;
+        }
+
+        let { mode, width, height, portrait } = nextProps.noTestWrapConfig;
+        this.setDefaultConfig(mode, {
+            width,
+            height,
+            portrait
+        });
+    }
+
     componentWillMount() {
+        if (this.props.noTestWrapConfig) return;
+
         let config = this.props.config;
         let mode = Object.keys(config)[0];
+        this.setDefaultConfig(mode, config[mode]);
+    }
+
+    setDefaultConfig(mode, config) {
         this.setState({
             mode: mode,
             viewport: {
-                height: config[mode].height,
-                width: config[mode].width
-            }
+                height: config.height,
+                width: config.width
+            },
+            portrait: config.portrait || this.state.portrait
         });
     }
 
@@ -71,7 +113,7 @@ export default class LayoutTester extends Component {
             return;
         }
         let { height, width } = this.props.config[mode];
-        let viewport = portrait ? { height, width } : { height : width, width  : height };
+        let viewport = portrait ? { height, width } : { height: width, width: height };
         let newState = {
             mode,
             viewport,
@@ -99,6 +141,10 @@ export default class LayoutTester extends Component {
     }
 
     render() {
+        if (this.props.noTestWrapConfig) {
+            return this.props.children;
+        }
+
         let { viewport } = this.state;
         let buttons = Object.keys(this.props.config).map(k => {
             return (

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ import {
 } from "react-native";
 
 import styles from "./styles";
+import getLayout from './getLayout';
+
+export { getLayout };
 
 export default class LayoutTester extends Component {
 
@@ -40,6 +43,16 @@ export default class LayoutTester extends Component {
     state = {
         portrait: true
     };
+
+    static childContextTypes = {
+      layoutTesterState: PropTypes.object
+    };
+
+    getChildContext() {
+        return {
+            layoutTesterState: this.state
+        };
+    }
 
     componentWillMount() {
         let config = this.props.config;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Gustavo Machado (machadogj@gmail.com)",
   "license": "MIT",
   "dependencies": {
-    "hoist-non-react-statics": "^1.0.6"
+    "hoist-non-react-statics": "^1.0.6",
+    "shallowequal": "^0.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Gustavo Machado (machadogj@gmail.com)",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "hoist-non-react-statics": "^1.0.6"
+  }
 }


### PR DESCRIPTION
Related #1.
### The `getLayout` decorator

``` js
import { Component } from 'react';
import { getLayout } from 'react-native-layout-tester';

class Comp extends Component {
  render() {
    const { mode, viewport, portrait } = this.props;
    return ( ... );
  }
}

export default getLayout(layout => layout)(Comp);
```

Or use `babel-plugin-transform-decorators-legacy` to support decorators syntax.
### The `noTestWrapConfig` prop

It's very useful in production, see following example for `react-native-orientation` and `react-native-extra-dimensions-android`:

``` js
import React, { Component, PropTypes } from "react";
import { Platform, Dimensions } from "react-native";
import LayoutTester from 'react-native-layout-tester';
import Orientation from 'react-native-orientation';
import ExtraDimensions from "react-native-extra-dimensions-android";

let statusBarHeight = 0;
if (Platform.OS === "android") {
  try {
    statusBarHeight = ExtraDimensions.get("STATUS_BAR_HEIGHT");
  } catch(e) {}
}

class App extends Component {

  state = {
    orientation: Orientation.getInitialOrientation()
  };

  _orientationDidChange = orientation => {
    this.setState({ orientation });
  };

  componentDidMount() {
    Orientation.addOrientationListener(this._orientationDidChange);
  }

  componentWillUnmount() {
    Orientation.removeOrientationListener(this._orientationDidChange);
  }

  render() {
    const { width, height } = Dimensions.get('window');
    return (
      <LayoutTester noTestWrapConfig={{
        mode: 'default',
        width,
        height: height - statusBarHeight,
        portrait: this.state.orientation === 'PORTRAIT'
      }}>
        ...
      </LayoutTester>
    );
  }
}
```

As result, we can keep use  `getLayout` decorator in development and production mode.
